### PR TITLE
Updating the link for refrence project

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A [Ulauncher](https://ulauncher.io/) extension to support `gnome-session-quit`.
 
 Icons are part of the [Faenza icon set by tiheum](https://tiheum.deviantart.com/art/Faenza-Icons-173323228).
 
-This extension was inspired by [Exit Cinnamon](https://github.com/seqizz/ulauncher-exit-cinnamon).
+This extension was inspired by ['Ulauncher Session Actions'](https://github.com/seqizz/ulauncher-session-actions) Formerly known as Exit Cinnamon.


### PR DESCRIPTION
It reference project name is changed to "ulauncher-session-actions".
Formerly known as: 'ulauncher-exit-cinnamon'